### PR TITLE
docs: refine project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,29 @@
 # ai_midi
 
-ai_midi is a Python 3.12+ toolkit to train and run generative MIDI models using a REMI-like tokenization, a GPT-style Transformer (PyTorch + PyTorch Lightning), and Hydra configuration. It provides CLI tools to preprocess datasets, train, and generate new MIDI samples, plus an optional FastAPI server.
+[![Python Version](https://img.shields.io/badge/Python-3.12%2B-blue.svg)](https://www.python.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+
+`ai_midi` is a Python toolkit for training and generating MIDI with REMI-like tokenization, a GPT-style Transformer powered by PyTorch Lightning, and Hydra-based configuration. It ships with CLI tools to preprocess datasets, train models, sample new music, and even an optional FastAPI server.
+
+## Table of Contents
+
+- [Features](#features)
+- [Installation](#installation)
+- [Quickstart](#quickstart)
+- [Configuration](#configuration)
+- [Dataset Preparation Tips](#dataset-preparation-tips)
+- [Troubleshooting & Tuning](#troubleshooting--tuning)
+- [Testing](#testing)
+- [License](#license)
 
 ## Features
 
-- Tokenization: simple REMI-like scheme with combined Note(pitch,duration), Velocity bins, ProgramChange, TimeShift, and special tokens.
-- Training: LightningModule Transformer with AMP, checkpointing, cosine/linear LR schedule, gradient clipping.
-- Dataset: sliding-window token sequences with on-disk caching.
-- Inference: top-k / top-p / temperature sampling, greedy, EOS stopping.
-- CLI and optional FastAPI server.
-- Hydra configs, structured logging, seeding for reproducibility.
+- REMI-inspired tokenization with combined `Note(pitch,duration)` tokens, velocity bins, program changes, time shifts, and special tokens.
+- Lightning-powered Transformer training (AMP, checkpointing, cosine/linear LR schedule, gradient clipping).
+- Sliding-window dataset with on-disk caching.
+- Flexible sampling: top-k, top-p, temperature, greedy, and EOS stopping.
+- Command-line tools and optional FastAPI server.
+- Hydra configs, structured logging, and reproducible seeding.
 
 ## Installation
 
@@ -20,31 +34,30 @@ pip install -e .[dev]
 pre-commit install
 ```
 
-Note: Installing `torch` may vary by platform/GPU. See https://pytorch.org/get-started/locally/ for the best command for your system.
+See [PyTorch's installation guide](https://pytorch.org/get-started/locally/) for platform-specific `torch` wheels.
 
 ## Quickstart
 
-1) Put MIDI files in a folder, e.g., `data/midi/`.
-
-2) Preprocess (optional – dataset also processes on the fly and caches):
+1. Place MIDI files in a folder, e.g. `data/midi/`.
+2. *(Optional)* Preprocess and cache sequences:
 
 ```bash
 ai_midi preprocess --midi-dir data/midi --out-cachedir data/cache
 ```
 
-3) Train with defaults:
+3. Train a model:
 
 ```bash
 ai_midi train
 ```
 
-Or specify config overrides (Hydra):
+   Override any config via Hydra:
 
 ```bash
 ai_midi train train.max_epochs=2 model.d_model=256 data.seq_len=256
 ```
 
-4) Generate from a short prompt:
+4. Generate new music from a prompt:
 
 ```bash
 ai_midi generate --prompt examples/sample_prompt.mid --out out.mid --max-tokens 256 --temp 1.0 --top_k 50 --top_p 0.95
@@ -52,21 +65,21 @@ ai_midi generate --prompt examples/sample_prompt.mid --out out.mid --max-tokens 
 
 ## Configuration
 
-Configs live under `src/midigegen/config/` and are composed via Hydra. The root `config.yaml` merges `model.yaml`, `data.yaml`, and `train.yaml`. You can override any key from the CLI.
+Configurations live in `src/midigegen/config/` and are composed with Hydra. The base `config.yaml` includes `model.yaml`, `data.yaml`, and `train.yaml`. Override any key from the CLI.
 
 ## Dataset Preparation Tips
 
-- Prefer well-quantized MIDI with consistent tempos.
-- Remove metadata tracks when not needed; focus on melodic/drum tracks you care about.
-- Our tokenizer quantizes to a fixed step; consider setting it to match your musical grid (e.g., 1/32 or 1/64 note).
-- Normalize tempos for determinism when training.
+- Use well-quantized MIDI with consistent tempos.
+- Remove unneeded metadata tracks; focus on relevant melodic or drum tracks.
+- Match the tokenizer's step size to your musical grid (e.g., 1/32 or 1/64).
+- Normalize tempos when training.
 
 ## Troubleshooting & Tuning
 
-- If memory is tight, reduce `model.d_model`, `model.n_layers`, `data.seq_len`, and `train.batch_size`.
-- Start with greedy or top-k sampling and adjust `temperature` and `top_p` for diversity.
-- Warmup steps (`train.warmup_steps`) can stabilize early training.
-- Ensure your dataset has sufficient musical variety; augmentation (transpose) may help.
+- Reduce `model.d_model`, `model.n_layers`, `data.seq_len`, or `train.batch_size` if memory is tight.
+- Start with greedy or top-k sampling, then adjust `temperature` and `top_p` for diversity.
+- `train.warmup_steps` can stabilize early training.
+- Augment or transpose MIDI for more variety.
 
 ## Testing
 
@@ -78,4 +91,5 @@ pytest -q
 
 ## License
 
-MIT. See `LICENSE`.
+Released under the MIT license. See [`LICENSE`](LICENSE) for details.
+


### PR DESCRIPTION
## Summary
- refresh README with badges, table of contents, and clearer quickstart instructions

## Testing
- `pytest -q -c /dev/null` *(fails: ModuleNotFoundError: No module named 'ai_midi')*


------
https://chatgpt.com/codex/tasks/task_e_68c33a42da84832cb1aeaf12f3227c00